### PR TITLE
Reserve right to amend and repeal provisions

### DIFF
--- a/template.md
+++ b/template.md
@@ -67,6 +67,8 @@ subtitle: "{{corporation.name}}"
     
     <!--- City of Providence v. First Citizens Bancshares, 99 A.3d 229 (Del. Ch. 2014) -->
 
+10. This certificate grants rights to stockholders subject to the corporation's right to amend and repeal any provision of this certificate as prescribed by statute.
+
 <!--- Default Rules -->
 
 <!--- DGCL 102(b)(5): provision limiting the duration of the corporation's existence ... otherwise ... perpetual -->


### PR DESCRIPTION
A more orthodox rendering:

> The corporation reserves the right to amend, alter, change or repeal
> any provision contained in this Certificate of Incorporation, in
> the manner now or hereafter prescribed by statute, and all rights
> conferred upon the stockholders herein are granted subject to this
> reservation.
